### PR TITLE
Prevent const reassign

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: node_js
 node_js:
+- 'stable'
+- '6'
+- '5'
 - '4'
 cache:
   directories:

--- a/bin/docpress
+++ b/bin/docpress
@@ -30,7 +30,7 @@ function run () {
 }
 
 function docpress (cwd) {
-  const app = require('docpress-core/ms')(cwd)
+  var app = require('docpress-core/ms')(cwd)
   const meta = app.metadata()
 
   // Set default plugins


### PR DESCRIPTION
It throws `TypeError: Assignment to constant variable.` under node 6