### PR TITLE
Remove docpress-search and references

### DIFF
--- a/docs/advanced/hacking.md
+++ b/docs/advanced/hacking.md
@@ -20,7 +20,6 @@ cd ~/Projects/docpress
 git clone http://github.com/docpress/docpress.git
 git clone http://github.com/docpress/docpress-base.git
 git clone http://github.com/docpress/docpress-core.git
-git clone http://github.com/docpress/docpress-search.git
 ```
 
 #### Link them all
@@ -30,7 +29,6 @@ Use `npm link` so you can use them as local development copies.
 (cd docpress && npm link)
 (cd docpress-base && npm link)
 (cd docpress-core && npm link)
-(cd docpress-search && npm link)
 ```
 
 #### Use the links
@@ -39,5 +37,4 @@ Use the linked development copies.
 ```sh
 (cd docpress && npm i && npm link docpress-base && npm link docpress-core)
 (cd docpress-base && npm i && npm link npm link docpress-core)
-(cd docpress-search && npm i && npm link npm link docpress-core)
 ```

--- a/docs/docpress.json
+++ b/docs/docpress.json
@@ -12,7 +12,6 @@
   },
   "plugins": {
     "docpress-core": {},
-    "docpress-search": {},
     "docpress-base": {}
   },
   "googleAnalytics": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "docpress-base": "0.6.10",
     "docpress-core": "0.6.13",
-    "docpress-search": "0.6.0",
     "eslint": "2.0.0",
     "eslint-config-standard": "5.2.0",
     "eslint-plugin-standard": "1.3.1",


### PR DESCRIPTION
- Remove module/plugin reference.
- Remove mention in the docs, since it's no longer required for hacking.

Resolves #38

Related: https://github.com/docpress/docpress-base/pull/130